### PR TITLE
Extend support to Next.js 15-16 and React 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cronitor RUM Next.js integration
 
-> **Important:** As of version 0.2.0 of this package only Next.js 13 or later will be supported. Version 0.5.0 adds official support for Next.js 14. For previous versions of Next.js please install version 0.1.0 of this package.
+> **Important:** As of version 0.2.0 of this package only Next.js 13 or later will be supported. Version 0.5.0 adds official support for Next.js 13, 14, 15, and 16. For previous versions of Next.js please install version 0.1.0 of this package.
 
 Official [Cronitor Real User Monitoring](https://cronitor.io/real-user-monitoring) integration for Next.js.
 
@@ -68,7 +68,8 @@ export default CustomApp;
 
 ### 0.5.0
 
-- Add official support for Next.js 14.
+- Add official support for Next.js 13, 14, 15, and 16.
+- Add support for React 19.
 - Update TypeScript to version 5.
 
 ### 0.4.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cronitor RUM Next.js integration
 
-> **Important:** As of version 0.2.0 of this package only Next.js 13 or later will be supported. Version 0.5.0 adds official support for Next.js 13, 14, 15, and 16. For previous versions of Next.js please install version 0.1.0 of this package.
+> **Important:** As of version 0.2.0 of this package only Next.js 13 or later will be supported. Version 0.5.0 adds official support for Next.js 14-16. For previous versions of Next.js please install version 0.1.0 of this package.
 
 Official [Cronitor Real User Monitoring](https://cronitor.io/real-user-monitoring) integration for Next.js.
 
@@ -68,7 +68,7 @@ export default CustomApp;
 
 ### 0.5.0
 
-- Add official support for Next.js 13, 14, 15, and 16.
+- Add official support for Next.js 14, 15, and 16.
 - Add support for React 19.
 - Update TypeScript to version 5.
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "lint": "tslint -p tsconfig.json"
   },
   "peerDependencies": {
-    "next": "^13 || ^14",
-    "react": "^18"
+    "next": "^13 || ^14 || ^15 || ^16",
+    "react": "^18 || ^19"
   },
   "dependencies": {
     "@cronitorio/cronitor-rum": "^0.4.0"


### PR DESCRIPTION
- Update peerDependencies to support Next.js ^13 || ^14 || ^15 || ^16
- Add React 19 support for Next.js 15+ compatibility
- Update changelog and documentation